### PR TITLE
FIX: ADD id field to JWT

### DIFF
--- a/src/main/java/com/example/career/global/jwt/TokenProvider.java
+++ b/src/main/java/com/example/career/global/jwt/TokenProvider.java
@@ -53,7 +53,7 @@ public class TokenProvider implements InitializingBean {
         return Jwts.builder()
                 .setSubject(authentication.getName())
                 .claim(AUTHORITIES_KEY, authorities)
-//                .claim("id", id)
+                .claim("id", id)    // 게시글 및 댓글 클릭시 내 댓글인지 여부 판단하는 데에 사용.
                 .claim("isTutor", isTutor)
                 .signWith(key, SignatureAlgorithm.HS512)
                 .setExpiration(validity)


### PR DESCRIPTION
JWT 토큰에 userId 값을 포함시킴. 커뮤니티의 게시글 및 댓글이 로그인한
본인의 것인지 여부를 판단하기 위해 JWT토큰의 userId 값을 사용함.

게시글 및 댓글의 userId와 JWT의 userId값이 같으면 수정 가능.
그렇지 않으면 수정 불가능.